### PR TITLE
Starknet Fetcher optimizations

### DIFF
--- a/crates/fetcher/src/proof_keys/evm.rs
+++ b/crates/fetcher/src/proof_keys/evm.rs
@@ -20,6 +20,7 @@ use types::{
     RPC_URL_ETHEREUM,
 };
 
+use super::FlattenedKey;
 use crate::FetcherError;
 
 #[derive(Debug, Default)]
@@ -29,12 +30,6 @@ pub struct ProofKeys {
     pub storage_keys: HashSet<keys::evm::storage::Key>,
     pub receipt_keys: HashSet<keys::evm::receipt::Key>,
     pub transaction_keys: HashSet<keys::evm::transaction::Key>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FlattenedKey {
-    pub chain_id: u128,
-    pub block_number: u64,
 }
 
 impl ProofKeys {

--- a/crates/fetcher/src/proof_keys/mod.rs
+++ b/crates/fetcher/src/proof_keys/mod.rs
@@ -10,6 +10,12 @@ use crate::FetcherError;
 pub mod evm;
 pub mod starknet;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FlattenedKey {
+    pub chain_id: u128,
+    pub block_number: u64,
+}
+
 #[derive(Debug, Default)]
 pub struct ProofKeys {
     pub evm: evm::ProofKeys,


### PR DESCRIPTION
- Extract FlattenedKey to a shared module
- Modify collect_starknet_headers_proofs to separate header fetching
- Update storage proof fetching to return only storage
- Add to_flattened_keys method for ProofKeys to generate unique block keys