### PR TITLE
feat: Add hashers module with Poseidon, Keccak, and Pedersen hash tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6259,6 +6259,7 @@ dependencies = [
 name = "tests_modules"
 version = "0.1.0"
 dependencies = [
+ "alloy 0.7.3",
  "cairo-lang-starknet-classes",
  "cairo-vm",
  "dry_hint_processor",
@@ -6267,6 +6268,7 @@ dependencies = [
  "hints",
  "serde_json",
  "sound_hint_processor",
+ "starknet-crypto",
  "syscall_handler",
  "tokio",
  "types",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 
 [dev-dependencies]
+alloy.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-vm.workspace = true
 dry_hint_processor.workspace = true
@@ -14,6 +15,7 @@ futures.workspace = true
 hints.workspace = true
 serde_json.workspace = true
 sound_hint_processor.workspace = true
+starknet-crypto.workspace = true
 tokio.workspace = true
 types.workspace = true
 syscall_handler.workspace = true

--- a/tests/src/hashers.cairo
+++ b/tests/src/hashers.cairo
@@ -1,0 +1,3 @@
+pub mod poseidon_modules;
+pub mod keccak_modules;
+pub mod pedersen_modules;

--- a/tests/src/hashers/keccak_modules.cairo
+++ b/tests/src/hashers/keccak_modules.cairo
@@ -1,0 +1,17 @@
+#[starknet::contract]
+mod hashers_keccak {
+    use core::keccak::{keccak_u256s_be_inputs};
+    use hdp_cairo::{HDP};
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    pub fn main(ref self: ContractState, hdp: HDP) {
+        let hash1 = keccak_u256s_be_inputs(array![1, 2, 3, 4].span());
+        let hash2 = keccak_u256s_be_inputs(array![1, 2, 3, 5].span());
+
+        assert!(hash1 == 0x2d9982dfaf468a9ddf7101b6323aa9d56510e6fd534f267a01086462df912739);
+        assert!(hash2 == 0x67cebf8d7d4a744b86437de146253d74fd06da9cd1a25494a707bd32c2d98bbd);
+    }
+}

--- a/tests/src/hashers/mod.rs
+++ b/tests/src/hashers/mod.rs
@@ -1,0 +1,43 @@
+use alloy::{
+    hex::FromHex,
+    primitives::{keccak256, FixedBytes, U256},
+};
+use cairo_vm::Felt252;
+use starknet_crypto::{pedersen_hash, poseidon_hash_many};
+
+pub mod tests_runner;
+
+#[tokio::test]
+async fn test_poseidon_hash_rust() {
+    let hash1 = poseidon_hash_many(&[Felt252::from(1), Felt252::from(2), Felt252::from(3), Felt252::from(4)]);
+    let hash2 = poseidon_hash_many(&[Felt252::from(1), Felt252::from(2), Felt252::from(3), Felt252::from(5)]);
+
+    assert!(hash1 == Felt252::from_hex("0x26e3ad8b876e02bc8a4fc43dad40a8f81a6384083cabffa190bcf40d512ae1d").unwrap());
+    assert!(hash2 == Felt252::from_hex("0x57b091966b9a59d46d961b416376fadeb9b0755fabe4d3b63bed65a613c9f3f").unwrap());
+}
+
+#[tokio::test]
+async fn test_keccak_hash_rust() {
+    let values = vec![U256::from(1), U256::from(2), U256::from(3), U256::from(4)];
+    let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_be_bytes::<32>()).collect();
+    let mut hash1 = keccak256(bytes.as_slice());
+    hash1.reverse();
+
+    assert!(hash1 == FixedBytes::from_hex("0x2d9982dfaf468a9ddf7101b6323aa9d56510e6fd534f267a01086462df912739").unwrap());
+
+    let values2 = vec![U256::from(1), U256::from(2), U256::from(3), U256::from(5)];
+    let bytes2: Vec<u8> = values2.iter().flat_map(|v| v.to_be_bytes::<32>()).collect();
+    let mut hash2 = keccak256(bytes2.as_slice());
+    hash2.reverse();
+
+    assert!(hash2 == FixedBytes::from_hex("0x67cebf8d7d4a744b86437de146253d74fd06da9cd1a25494a707bd32c2d98bbd").unwrap());
+}
+
+#[tokio::test]
+async fn test_perdersen_hash_rust() {
+    let hash1 = pedersen_hash(&Felt252::from_bytes_le_slice(&[1]), &Felt252::from_bytes_le_slice(&[2]));
+    let hash2 = pedersen_hash(&Felt252::from_bytes_le_slice(&[3]), &Felt252::from_bytes_le_slice(&[4]));
+
+    assert!(hash1 == Felt252::from_hex("0x5bb9440e27889a364bcb678b1f679ecd1347acdedcbf36e83494f857cc58026").unwrap());
+    assert!(hash2 == Felt252::from_hex("0x262697b88544f733e5c6907c3e1763131e9f14c51ee7951258abbfb29415fbf").unwrap());
+}

--- a/tests/src/hashers/pedersen_modules.cairo
+++ b/tests/src/hashers/pedersen_modules.cairo
@@ -1,0 +1,17 @@
+#[starknet::contract]
+mod hashers_pedersen {
+    use core::pedersen::{pedersen};
+    use hdp_cairo::{HDP};
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    pub fn main(ref self: ContractState, hdp: HDP) {
+        let hash1 = pedersen(1, 2);
+        let hash2 = pedersen(3, 4);
+
+        assert!(hash1 == 0x5bb9440e27889a364bcb678b1f679ecd1347acdedcbf36e83494f857cc58026);
+        assert!(hash2 == 0x262697b88544f733e5c6907c3e1763131e9f14c51ee7951258abbfb29415fbf);
+    }
+}

--- a/tests/src/hashers/poseidon_modules.cairo
+++ b/tests/src/hashers/poseidon_modules.cairo
@@ -1,0 +1,36 @@
+#[starknet::contract]
+mod hashers_poseidon {
+    use core::poseidon::{poseidon_hash_span, PoseidonImpl};
+    use core::hash::{HashStateTrait};
+    use hdp_cairo::{HDP};
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    pub fn main(ref self: ContractState, hdp: HDP) {
+        let hash1 = poseidon_hash_span(array![1, 2, 3, 4].span());
+        let mut hash1_alternative = PoseidonImpl::new()
+            .update(1)
+            .update(2)
+            .update(3)
+            .update(4)
+            .finalize();
+        let hash2 = poseidon_hash_span(array![1, 2, 3, 5].span());
+        let mut hash2_alternative = PoseidonImpl::new()
+            .update(1)
+            .update(2)
+            .update(3)
+            .update(5)
+            .finalize();
+
+        assert!(hash1 == 0x26e3ad8b876e02bc8a4fc43dad40a8f81a6384083cabffa190bcf40d512ae1d);
+        assert!(hash2 == 0x57b091966b9a59d46d961b416376fadeb9b0755fabe4d3b63bed65a613c9f3f);
+        assert!(
+            hash1_alternative == 0x26e3ad8b876e02bc8a4fc43dad40a8f81a6384083cabffa190bcf40d512ae1d,
+        );
+        assert!(
+            hash2_alternative == 0x57b091966b9a59d46d961b416376fadeb9b0755fabe4d3b63bed65a613c9f3f,
+        );
+    }
+}

--- a/tests/src/hashers/tests_runner.rs
+++ b/tests/src/hashers/tests_runner.rs
@@ -1,0 +1,28 @@
+use crate::test_utils::run;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_poseidon_hash() {
+    run(serde_json::from_slice(include_bytes!(
+        "../../../target/dev/modules_hashers_poseidon.compiled_contract_class.json"
+    ))
+    .unwrap())
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_keccak_hash() {
+    run(serde_json::from_slice(include_bytes!(
+        "../../../target/dev/modules_hashers_keccak.compiled_contract_class.json"
+    ))
+    .unwrap())
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_pedersen_hash() {
+    run(serde_json::from_slice(include_bytes!(
+        "../../../target/dev/modules_hashers_pedersen.compiled_contract_class.json"
+    ))
+    .unwrap())
+    .await
+}

--- a/tests/src/lib.cairo
+++ b/tests/src/lib.cairo
@@ -1,3 +1,4 @@
 pub mod evm;
 pub mod starknet;
 pub mod utils;
+pub mod hashers;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -11,6 +11,9 @@ pub mod starknet;
 pub mod utils;
 
 #[cfg(test)]
+pub mod hashers;
+
+#[cfg(test)]
 mod test_utils {
     use std::{env, path::PathBuf};
 


### PR DESCRIPTION
- Implement Rust and Cairo tests for different hash functions
- Add new modules for Poseidon, Keccak, and Pedersen hash tests
- Include test runners and module configurations
- Update Cargo dependencies to support new hash testing functionality