### PR TITLE
Fix: link to example.env in the docs

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -16,7 +16,7 @@
 
 2. **ENVs:**
    HDP CLI requires and RPC endpoint for Ethereum and Starknet.
-   Please expose env vars before running present in [.env](example.env)
+   Please expose env vars before running present in [.env](https://github.com/HerodotusDev/hdp-cairo/blob/main/example.env)
 
 ### Option 2: Building from Source
 
@@ -51,7 +51,7 @@
      cp example.env .env
      ```
 
-   - Edit the [.env](example.env) file to provide the correct RPC endpoints and configuration details.
+   - Edit the [.env](https://github.com/HerodotusDev/hdp-cairo/blob/main/example.env) file to provide the correct RPC endpoints and configuration details.
 
 ---
 
@@ -209,4 +209,4 @@ scarb build
    cargo nextest run
    ```
 
-> **Note:** Ensure that the environment variables from [.env](example.env) are set before running the tests.
+> **Note:** Ensure that the environment variables from [.env](https://github.com/HerodotusDev/hdp-cairo/blob/main/example.env) are set before running the tests.


### PR DESCRIPTION
As the title suggests, this PR aims to fix the redirect link so that it properly points to the example.env file in the repository.

When accessing the documentation via https://herodotusdev.github.io/hdp-cairo/ and clicking on the `.env` link, we're currently getting the following error:
![image](https://github.com/user-attachments/assets/6a62d74d-b74f-49af-b553-aa475c7fe72a)
